### PR TITLE
Fix log file encoding issue

### DIFF
--- a/Install-EVHelper.ps1
+++ b/Install-EVHelper.ps1
@@ -34,7 +34,7 @@ function Write-Log {
     )
     $Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     $LogEntry = "$Timestamp - [$Level] $Message"
-    $LogEntry | Out-File -FilePath $LogFilePath -Append
+    $LogEntry | Out-File -FilePath $LogFilePath -Append -Encoding unicode
 }
 
 Set-Content -Path $LogFilePath -Encoding Unicode -Value "


### PR DESCRIPTION
### Request Type
Bug fix

### What does this PR do?
Fixes incorrect encoding in the log file by explicitly setting Unicode encoding when writing the file.

### Solution
Used `Out-File -Encoding Unicode` in the logging function. Previously, the log function defaulted to ANSI encoding, which caused log files to contain unreadable characters. This fix makes it readable again.

### How was it tested?
Manually verified output log files on Windows 10/11 using Notepad and VS Code. Output now displays correctly.

### Related Issue
Closes Issue #2